### PR TITLE
Fix comments and add future plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ deprecates 17media/go-etcd
 
 # TODO
 
-add pusher annd client as sample script
+only push modified files as key to etcd, currently we push all keys in repo
 
 documentation
 

--- a/pusher/main.go
+++ b/pusher/main.go
@@ -219,7 +219,7 @@ func Pusher(etcdConn *clientv3.Client, root, etcdRoot string) {
 		log.Infof("unexpected number of kv")
 	}
 
-	// FIXME if ._info is empty, don't set etcdLastCommit to previous commit
+	// FIXME if ._info is empty, don't set etcdLastCommit to previous commit & push all keys in repo
 	// TODO: empty etcdLastCommit cause diff-tree to only print files of current commit.
 	filestr := runSingleCmdOrFatal(fmt.Sprintf("git diff-tree --no-commit-id --name-status -r %s %s %s", etcdLastCommit, commitHash, root))
 	// filter out files that are descendents of the rootpath


### PR DESCRIPTION
Currently we push all keys to etcd no matter what diff in commit.

should push only modified files.

also if previous commit can't be found through ._info, we consider etcd as uninitialized and push all keys